### PR TITLE
Fix AzureService kind check

### DIFF
--- a/src/services/__tests__/azureService.test.ts
+++ b/src/services/__tests__/azureService.test.ts
@@ -162,6 +162,11 @@ describe('AzureService', () => {
     it('should identify Linux app services by linuxFxVersion', () => {
       expect(service.isWindowsAppService(mockLinuxAppService)).toBe(false);
     });
+
+    it('should default to Windows when kind is missing', () => {
+      const noKindApp = { ...mockAppService, kind: undefined };
+      expect(service.isWindowsAppService(noKindApp as any)).toBe(true);
+    });
   });
 
   describe('getARMTemplateUri', () => {

--- a/src/services/azureService.ts
+++ b/src/services/azureService.ts
@@ -142,8 +142,10 @@ export class AzureService {
    * Determine if an App Service is running on Windows or Linux
    */
   isWindowsAppService(appService: AzureAppService): boolean {
+    const kind = appService.kind?.toLowerCase() || '';
+
     // Check the kind property for Linux indicators
-    if (appService.kind?.toLowerCase().includes('linux')) {
+    if (kind.includes('linux')) {
       return false;
     }
 


### PR DESCRIPTION
## Summary
- handle undefined `kind` when checking app service OS
- test that missing `kind` defaults to windows

## Testing
- `yarn lint` *(fails: package missing)*
- `yarn format` *(fails: package missing)*
- `yarn type-check` *(fails: package missing)*
- `yarn test` *(fails: package missing)*

------
https://chatgpt.com/codex/tasks/task_b_68783bea13dc8331b8af8a0e040db421