### PR TITLE
Fix ARM template URL

### DIFF
--- a/src/components/DatadogAPMForm.tsx
+++ b/src/components/DatadogAPMForm.tsx
@@ -129,8 +129,11 @@ const DatadogAPMForm: React.FC = () => {
   };
 
   const getARMTemplateUri = (isWindows: boolean): string => {
-    const baseUrl = window.location.origin;
-    return `${baseUrl}/arm/${isWindows ? 'windows' : 'linux'}-appservice-datadog.json`;
+    const { origin, pathname } = window.location;
+    const basePath = pathname.endsWith('/') ? pathname : `${pathname}/`;
+    return `${origin}${basePath}arm/${
+      isWindows ? 'windows' : 'linux'
+    }-appservice-datadog.json`;
   };
 
   const handleDeploy = async () => {

--- a/src/services/azureService.ts
+++ b/src/services/azureService.ts
@@ -160,8 +160,11 @@ export class AzureService {
    * Get ARM template URI based on platform
    */
   getARMTemplateUri(isWindows: boolean): string {
-    const baseUrl = window.location.origin;
-    return `${baseUrl}/arm/${isWindows ? 'windows' : 'linux'}-appservice-datadog.json`;
+    const { origin, pathname } = window.location;
+    const basePath = pathname.endsWith('/') ? pathname : `${pathname}/`;
+    return `${origin}${basePath}arm/${
+      isWindows ? 'windows' : 'linux'
+    }-appservice-datadog.json`;
   }
 
   /**


### PR DESCRIPTION
## Summary
- use pathname to compute base URL for ARM template
- update DatadogAPMForm to use new base URL logic

## Testing
- `yarn lint` *(fails: package missing)*
- `yarn type-check` *(fails: package missing)*
- `yarn test:coverage` *(fails: package missing)*

------
https://chatgpt.com/codex/tasks/task_b_68783bea13dc8331b8af8a0e040db421