### PR TITLE
Refactor duplicated constants

### DIFF
--- a/src/components/DatadogAPMForm.tsx
+++ b/src/components/DatadogAPMForm.tsx
@@ -2,22 +2,14 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useMsal } from '@azure/msal-react';
 import { loginRequest, armApiRequest } from '../authConfig';
 import { AzureService } from '../services/azureService';
+import { DATADOG_SITES } from '../types/index';
 import {
   AzureSubscription,
   AzureAppService,
-  DatadogSite,
   DeploymentParameters,
 } from '../types';
 import LoadingSpinner from './LoadingSpinner';
 import ErrorAlert from './ErrorAlert';
-
-const DATADOG_SITES: DatadogSite[] = [
-  { value: 'datadoghq.com', label: 'US1 (datadoghq.com)' },
-  { value: 'datadoghq.eu', label: 'EU1 (datadoghq.eu)' },
-  { value: 'us3.datadoghq.com', label: 'US3 (us3.datadoghq.com)' },
-  { value: 'us5.datadoghq.com', label: 'US5 (us5.datadoghq.com)' },
-  { value: 'ap1.datadoghq.com', label: 'AP1 (ap1.datadoghq.com)' },
-];
 
 const DatadogAPMForm: React.FC = () => {
   const { instance, accounts } = useMsal();
@@ -141,14 +133,6 @@ const DatadogAPMForm: React.FC = () => {
     }
   };
 
-  const getARMTemplateUri = (isWindows: boolean): string => {
-    const { origin, pathname } = window.location;
-    const basePath = pathname.endsWith('/') ? pathname : `${pathname}/`;
-    return `${origin}${basePath}arm/${
-      isWindows ? 'windows' : 'linux'
-    }-appservice-datadog.json`;
-  };
-
   const handleDeploy = async () => {
     if (!accessToken || !selectedAppService || !ddApiKey) {
       setError('Please fill in all required fields');
@@ -181,7 +165,7 @@ const DatadogAPMForm: React.FC = () => {
 
       // Determine if it's Windows or Linux
       const isWindows = azureService.isWindowsAppService(selectedApp);
-      const templateUri = getARMTemplateUri(isWindows);
+      const templateUri = azureService.getARMTemplateUri(isWindows);
 
       const deploymentParameters: DeploymentParameters = {
         siteName: selectedApp.name,

--- a/src/hooks/useAzureApi.ts
+++ b/src/hooks/useAzureApi.ts
@@ -4,7 +4,7 @@ import {
   AzureSubscription,
   AzureAppService,
   DeploymentParameters,
-} from '../types';
+} from '../types/index';
 
 // Query keys
 const QUERY_KEYS = {


### PR DESCRIPTION
## Summary
- centralize DATADOG_SITES constant
- reuse AzureService's ARM template helper
- update hooks to reference shared types

## Testing
- `npx eslint src --fix`
- `npx tsc --noEmit`
- `npx react-scripts test --runInBand` *(fails: console error about act wrapping)*

------
https://chatgpt.com/codex/tasks/task_b_6878e73d01488331ac94d9471a326e84