### PR TITLE
Fix TypeScript type errors in production build

### DIFF
--- a/src/components/DatadogAPMForm.tsx
+++ b/src/components/DatadogAPMForm.tsx
@@ -8,7 +8,7 @@ import {
   AzureAppService,
   DeploymentParameters,
   ResourceGroup,
-} from '../types';
+} from '../types/index';
 import LoadingSpinner from './LoadingSpinner';
 import ErrorAlert from './ErrorAlert';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,14 +12,14 @@ export interface AzureAppService {
   name: string;
   resourceGroup: string;
   location: string;
-  kind: string;
+  kind?: string | undefined;
   properties: {
     hostNames: string[];
     state: string;
     siteConfig?: {
-      linuxFxVersion?: string;
-      windowsFxVersion?: string;
-    };
+      linuxFxVersion?: string | undefined;
+      windowsFxVersion?: string | undefined;
+    } | undefined;
   };
 }
 

--- a/src/utils/typeGuards.ts
+++ b/src/utils/typeGuards.ts
@@ -69,7 +69,7 @@ export function isValidSubscriptionId(subscriptionId: string): boolean {
  */
 export function isLinuxAppService(appService: AzureAppService): boolean {
   return (
-    appService.kind.includes('linux') ||
+    appService.kind?.includes('linux') ||
     Boolean(appService.properties.siteConfig?.linuxFxVersion)
   );
 }


### PR DESCRIPTION
## Summary

This PR fixes TypeScript type errors that were preventing the production build from passing type checking.

## Changes Made

### 1. Import Path Fix
- Updated import from `'../types'` to `'../types/index'` in DatadogAPMForm.tsx
- This ensures proper module resolution for the types

### 2. Optional Property Type Safety
- Made optional properties explicitly typed with `| undefined` annotations in AzureAppService interface:
  - `kind?: string | undefined`
  - `linuxFxVersion?: string | undefined`
  - `windowsFxVersion?: string | undefined`
  - `siteConfig?: {...} | undefined`

### 3. Runtime Safety Improvements  
- Added optional chaining (`?.`) for `appService.kind` access in typeGuards.ts
- This prevents runtime errors when `kind` property is undefined

## Verification
- ✅ `yarn tsc --noEmit --project tsconfig.prod.json` now passes without errors
- ✅ All type safety improvements maintain backward compatibility

## Files Changed
- `src/components/DatadogAPMForm.tsx`
- `src/types.ts`  
- `src/utils/typeGuards.ts`

These changes ensure the production TypeScript build is fully type-safe while maintaining all existing functionality.