### PR TITLE
Fix TFLint GitHub API rate limit issue

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -143,10 +143,14 @@ jobs:
       - name: Initialize TFLint
         run: tflint --init
         working-directory: ${{ env.TERRAFORM_DIR }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run TFLint
         run: tflint --format compact
         working-directory: ${{ env.TERRAFORM_DIR }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   tfsec:
     name: tfsec Security Analysis


### PR DESCRIPTION
Fixes GitHub Actions failure where TFLint hits API rate limits when installing the azurerm plugin.

**Changes:**
- Added GITHUB_TOKEN authentication to TFLint initialization and execution steps
- This provides authenticated GitHub API requests with higher rate limits

**Issue:**
TFLint was making unauthenticated requests to GitHub API when installing plugins, causing rate limit errors:
```
403 API rate limit exceeded for 52.242.243.96. (But here's the good news: Authenticated requests get a higher rate limit.)
```

**Solution:**
Added `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` environment variable to authenticate API requests.